### PR TITLE
Bridging external detector

### DIFF
--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -1081,6 +1081,7 @@ class TopDownPerson(dj.Computed):
             key["keypoints"] = (BottomUpPerson & key & {"bottom_up_method_name": "OpenPose_HR"}).fetch1("keypoints")
         elif method_name == "OpenPose_LR":
             key["keypoints"] = (BottomUpPerson & key & {"bottom_up_method_name": "OpenPose_LR"}).fetch1("keypoints")
+
         elif method_name == "Bridging_COCO_25":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
@@ -1090,6 +1091,7 @@ class TopDownPerson(dj.Computed):
             # Filter out keypoints that are outside of the image since confidence estimates do
             # not capture this
             key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
         elif method_name == "Bridging_bml_movi_87":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
@@ -1099,6 +1101,7 @@ class TopDownPerson(dj.Computed):
             # Filter out keypoints that are outside of the image since confidence estimates do
             # not capture this
             key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
         elif method_name == "Bridging_smpl+head_30":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
@@ -1108,6 +1111,79 @@ class TopDownPerson(dj.Computed):
             # Filter out keypoints that are outside of the image since confidence estimates do
             # not capture this
             key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
+        elif method_name == "Bridging_ExtDetector_COCO_25":
+            from pose_pipeline.wrappers.bridging import bridging_formats_with_external_bbox
+            from pose_pipeline.wrappers.bridging import filter_skeleton
+            from pose_pipeline.wrappers.bridging import noise_to_conf
+            from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
+
+            # Define external bbox from PersonBbox
+            ext_bbox = (PersonBbox & key).fetch1("bbox")
+            bbox_present = (PersonBbox & key).fetch1("present")
+
+            # Perform bridging, extract keypoints and noise
+            results = bridging_formats_with_external_bbox(key, ext_bbox, bbox_present)
+            keypoints2d = results['keypoints2d']
+            keypoints3d = results['keypoints3d']
+            keypoints_noise = results['keypoint_noise']
+            conf = noise_to_conf(keypoints_noise)
+            keypoints_2d_conf= np.array([np.concatenate([k, c[:, None]], axis=1) for k, c in zip(keypoints2d, conf)])
+
+            # Assign keypoints to the key
+            key["keypoints"] = keypoints_2d_conf
+            key["keypoints"] = np.array(filter_skeleton(key["keypoints"], "coco_25"))
+            # Filter out keypoints that are outside of the image since confidence estimates do not capture this
+            key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
+        elif method_name == "Bridging_ExtDetector_bml_movi_87":
+            from pose_pipeline.wrappers.bridging import bridging_formats_with_external_bbox
+            from pose_pipeline.wrappers.bridging import filter_skeleton
+            from pose_pipeline.wrappers.bridging import noise_to_conf
+            from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
+
+            # Define external bbox from PersonBbox
+            ext_bbox = (PersonBbox & key).fetch1("bbox")
+            bbox_present = (PersonBbox & key).fetch1("present")
+
+            # Perform bridging, extract keypoints and noise
+            results = bridging_formats_with_external_bbox(key, ext_bbox, bbox_present)
+            keypoints2d = results['keypoints2d']
+            keypoints3d = results['keypoints3d']
+            keypoints_noise = results['keypoint_noise']
+            conf = noise_to_conf(keypoints_noise)
+            keypoints_2d_conf= np.array([np.concatenate([k, c[:, None]], axis=1) for k, c in zip(keypoints2d, conf)])
+
+            # Assign keypoints to the key
+            key["keypoints"] = keypoints_2d_conf
+            key["keypoints"] = np.array(filter_skeleton(key["keypoints"], "bml_movi_87"))
+            # Filter out keypoints that are outside of the image since confidence estimates do not capture this
+            key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
+        elif method_name == "Bridging_ExtDetector_smpl+head_30":
+            from pose_pipeline.wrappers.bridging import bridging_formats_with_external_bbox
+            from pose_pipeline.wrappers.bridging import filter_skeleton
+            from pose_pipeline.wrappers.bridging import noise_to_conf
+            from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
+
+            # Define external bbox from PersonBbox
+            ext_bbox = (PersonBbox & key).fetch1("bbox")
+            bbox_present = (PersonBbox & key).fetch1("present")
+
+            # Perform bridging, extract keypoints and noise
+            results = bridging_formats_with_external_bbox(key, ext_bbox, bbox_present)
+            keypoints2d = results['keypoints2d']
+            keypoints3d = results['keypoints3d']
+            keypoints_noise = results['keypoint_noise']
+            conf = noise_to_conf(keypoints_noise)
+            keypoints_2d_conf= np.array([np.concatenate([k, c[:, None]], axis=1) for k, c in zip(keypoints2d, conf)])
+
+            # Assign keypoints to the key
+            key["keypoints"] = keypoints_2d_conf
+            key["keypoints"] = np.array(filter_skeleton(key["keypoints"], "smpl+head_30"))
+            # Filter out keypoints that are outside of the image since confidence estimates do not capture this
+            key["keypoints"] = keypoints_filter_clipped_image(key, key["keypoints"])
+
         elif method_name == "MMPose_RTMPose_Coco_Wholebody":
             from .wrappers.mmpose import mmpose_top_down_person
             key["keypoints"] = mmpose_top_down_person(key, "RTMPose_coco-wholebody")

--- a/pose_pipeline/wrappers/bridging.py
+++ b/pose_pipeline/wrappers/bridging.py
@@ -142,71 +142,6 @@ def bridging_formats_bottom_up(key, model=None, skeleton=""):
     return {"boxes": boxes, "keypoints2d": keypoints2d, "keypoints3d": keypoints3d, "keypoint_noise": keypoint_noises}
 
 
-# Define bbox conversion function: tlhw to tlbr
-def tlhw_to_tlbr_batch(tlhw_boxes):
-    """
-    Convert multiple bounding boxes from [x1, y1, width, height] to [x1, y1, x2, y2].
-
-    Parameters:
-        tlhw_boxes (array-like): Nx4 array-like (e.g. list of lists or NumPy array)
-                                 where each row is [x1, y1, width, height]
-
-    Returns:
-        np.ndarray: Nx4 array of boxes in [x1, y1, x2, y2] format
-    """
-    tlhw_boxes = np.asarray(tlhw_boxes)
-    x1y1 = tlhw_boxes[:, :2]
-    wh = tlhw_boxes[:, 2:]
-    x2y2 = x1y1 + wh
-    return np.hstack((x1y1, x2y2))
-
-
-# Define cropping function to crop image to bbox
-def crop_image_to_bbox(image, bbox, padding_ratio=0.2):
-    """
-    Crop image to bbox with padding.
-    
-    Args:
-        image: RGB image array
-        bbox: [x1, y1, x2, y2] in TLBR format
-        padding_ratio: Amount of padding to add (0.2 = 20%)
-    Returns:
-        cropped_image: Cropped RGB image array
-        crop_params: Dict with crop parameters for remapping keypoints
-    """
-
-    # Handle case where bbox is shape (1, 4) instead of (4,)
-    if bbox.ndim > 1:
-        bbox = bbox[0]  # Take first bbox if multiple
-
-    x1, y1, x2, y2 = bbox
-    w, h = x2 - x1, y2 - y1
-    
-    # Add padding
-    pad_w = w * padding_ratio
-    pad_h = h * padding_ratio
-    x1_pad = max(0, x1 - pad_w)
-    y1_pad = max(0, y1 - pad_h)
-    x2_pad = min(image.shape[1], x2 + pad_w)
-    y2_pad = min(image.shape[0], y2 + pad_h)
-    
-    # Crop image
-    crop = image[int(y1_pad):int(y2_pad), int(x1_pad):int(x2_pad)]
-    
-    return crop, {"offset_x": x1_pad, "offset_y": y1_pad}
-
-
-# Define remapping function to remap keypoints back to original image coordinates
-def remap_keypoints(keypoints, crop_params):
-    """
-    Remap keypoints from crop coordinates back to original image coordinates.
-    """
-    keypoints_mapped = keypoints.copy()
-    keypoints_mapped[..., 0] += crop_params["offset_x"]
-    keypoints_mapped[..., 1] += crop_params["offset_y"]
-    return keypoints_mapped
-
-
 # Bridging with focused keypoint detection using external bounding boxes
 def bridging_formats_with_external_bbox(key, external_bboxes, bbox_present, model=None, skeleton=""):
     """
@@ -231,9 +166,6 @@ def bridging_formats_with_external_bbox(key, external_bboxes, bbox_present, mode
     cap = cv2.VideoCapture(video)
     video_length = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
-    # Convert external bounding boxes from [x, y, width, height] to [x1, y1, x2, y2]
-    external_bboxes_tlbr = tlhw_to_tlbr_batch(external_bboxes)
-
     boxes = []
     keypoints2d = []
     keypoints3d = []
@@ -248,43 +180,32 @@ def bridging_formats_with_external_bbox(key, external_bboxes, bbox_present, mode
 
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
-        # If no bounding box is present, append empty arrays
+        # If no bounding box is present, append empty arrays (make sure they match the expected shape)
         if not bbox_present[frame_idx]:     
             boxes.append(np.zeros((0, 4)))
-            keypoints2d.append(np.zeros((model.per_skeleton_indices[skeleton].shape[0], 2)))
-            keypoints3d.append(np.zeros((model.per_skeleton_indices[skeleton].shape[0], 3)))
-            keypoint_noises.append(np.zeros((model.per_skeleton_indices[skeleton].shape[0],)))
+            keypoints2d.append(np.zeros((1, model.per_skeleton_indices[skeleton].shape[0], 2)))
+            keypoints3d.append(np.zeros((1, model.per_skeleton_indices[skeleton].shape[0], 3)))
+            keypoint_noises.append(np.zeros((1, model.per_skeleton_indices[skeleton].shape[0])))
             continue
         
-        # Get the external bounding box for the current frame
-        bbox = external_bboxes_tlbr[frame_idx]
-        if bbox.ndim == 1:
-            bbox = bbox[None, :]  # shape (1, 4)
-        
-        # Crop image to the bbox
-        crop, crop_params = crop_image_to_bbox(frame, bbox, padding_ratio=0.2)
+        # Convert bbox to Tensor format
+        bbox = tf.convert_to_tensor([external_bboxes[frame_idx]], dtype=tf.float32)
 
-        # Run detection on the cropped images
-        pred = model.detect_poses(crop, skeleton=skeleton, num_aug=10, average_aug=False,
-                                  detector_flip_aug=True, detector_threshold=0.1)
+        # Run MeTRAbs estimate_poses with the external bounding box
+        # pred is a dictionary with keys: "poses2d", "poses3d", "bbox", "bbox_used"
+        pred = model.estimate_poses(frame, bbox, skeleton=skeleton, num_aug=10, average_aug=False)
 
-        # Get keypoints and ensure consistent shape
-        kp2d = np.mean(pred["poses2d"].numpy(), axis=1)         # Average over augmentations
-        kp2d_mapped = remap_keypoints(kp2d, crop_params)
-        kp3d = np.mean(pred["poses3d"].numpy(), axis=1)
-        
-        # Ensure we have at least one detection
-        if len(kp2d_mapped) > 0:
-            # Take first detection if multiple found in crop
-            if len(kp2d_mapped) > 1:
-                kp2d_mapped = kp2d_mapped[0:1]  # Keep shape as (1, num_joints, 2)
-                kp3d = kp3d[0:1]                # Keep shape as (1, num_joints, 3)
-            
-            boxes.append(bbox)
-            keypoints2d.append(kp2d_mapped)
-            keypoints3d.append(kp3d)
-            keypoint_noises.append(augmentation_noise(pred["poses3d"].numpy())[0:1])
+        # Append results
+        boxes.append(bbox)
+        keypoints2d.append(np.mean(pred["poses2d"].numpy(), axis=1))
+        keypoints3d.append(np.mean(pred["poses3d"].numpy(), axis=1))
+        keypoint_noises.append(augmentation_noise(pred["poses3d"].numpy()))
 
+    # Convert to arrays and reshape
+    keypoints2d = np.squeeze(np.array(keypoints2d), axis=1)             # shape: (N, J, 2)
+    keypoints3d = np.squeeze(np.array(keypoints3d), axis=1)             # shape: (N, J, 3)
+    keypoint_noises = np.squeeze(np.array(keypoint_noises), axis=1)     # shape: (N, J)
+    
     cap.release()
     os.remove(video)
 


### PR DESCRIPTION
Added Bridging using an externally determined bounding box as a Top Down Method:

**`bridging.py`:** 
- added a function (`bridging_formats_with_external_bbox`) that performs bridging from an externally provided bounding box using MeTRAbs `estimate_poses` function

**`pipeline.py`:** 
- added Bridging from external detector as a TopDownPerson (for COCO_25, BML_MOVI_87, smpl+head_30, and smplx_42)
- added each of these methods into TopDownMethodLookup
- added forced population of LiftingPerson if one of these methods is chosen