### PR TITLE
Firebase update

### DIFF
--- a/pose_pipeline/utils/video_format.py
+++ b/pose_pipeline/utils/video_format.py
@@ -8,7 +8,7 @@ def compress(fn, bitrate=5):
     import subprocess
 
     fd, temp = tempfile.mkstemp(suffix=".mp4")
-    subprocess.run(["ffmpeg", "-y", "-i", fn, "-c:v", "libx264", "-b:v", f"{bitrate}M", temp])
+    subprocess.run(["ffmpeg", "-y", "-i", fn, "-c:v", "libx264", "-b:v", f"{bitrate}M", "-vsync", "vfr", temp])
     os.close(fd)
     return temp
 

--- a/pose_pipeline/utils/video_format.py
+++ b/pose_pipeline/utils/video_format.py
@@ -8,7 +8,7 @@ def compress(fn, bitrate=5):
     import subprocess
 
     fd, temp = tempfile.mkstemp(suffix=".mp4")
-    subprocess.run(["ffmpeg", "-y", "-i", fn, "-c:v", "libx264", "-b:v", f"{bitrate}M", "-vsync", "vfr", temp])
+    subprocess.run(["ffmpeg", "-y", "-i", fn, "-c:v", "libx264", "-b:v", f"{bitrate}M", "-fps_mode", "vfr", temp])
     os.close(fd)
     return temp
 


### PR DESCRIPTION
Fixing ffmpeg command which sometimes resulted in errors when imported Firebase videos.

- Smartphones often record in variable frame rate mode
- The phone encoder may decide to choose a time base rate (tbr) depending on different factors like lighting, battery, or motion
- I saw that some videos were having the frame rate set to 120FPS, and those were the ones that had the extrapolate error
- I used ffprobe to check fps and tbr for the problematic video and a video that worked, and they were both 30fps, but the video that worked had 30 tbr while the problematic video had 120 tbr
- This issue occurs when we compress the video when importing. ffmpeg defaults to a fixed frame rate for .mp4, and I believe uses the tbr value as the fixed frame rate (probably give the highest possible resolution to representing the timestamp ticks)
- The ffmpeg process would duplicate frames to make the video be 120 FPS which caused the 'Unable to extrapolate more than 5 frames' error during import 
- I set this flag in the ffmpeg command `-fps_mode vfr` which just tells ffmpeg to preserve the original per-frame timestamps and it seems to fix the problem