### PR TITLE
Hand estimation tables populating scripts

### DIFF
--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -2123,7 +2123,7 @@ class HandPoseEstimationMethodLookup(dj.Lookup):
         {"estimation_method": 4, "estimation_method_name": "HRNet_udp"},
     ]
 
-    def joint_names(self,method=None):
+    def joint_names(self, method=None):
         if method is None:
             method = self.fetch1("estimation_method_name")
         if (

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -2123,8 +2123,9 @@ class HandPoseEstimationMethodLookup(dj.Lookup):
         {"estimation_method": 4, "estimation_method_name": "HRNet_udp"},
     ]
 
-    def joint_names(self):
-        method = self.fetch1("estimation_method_name")
+    def joint_names(self,method=None):
+        if method is None:
+            method = self.fetch1("estimation_method_name")
         if (
             method == "RTMPoseHand5"
             or method == "RTMPoseCOCO"

--- a/pose_pipeline/utils/standard_pipelines.py
+++ b/pose_pipeline/utils/standard_pipelines.py
@@ -351,23 +351,24 @@ def hand_estimation_pipeline(
     Args:
         keys (dict)                  : key or keys to compute
         detection_method_name (str)  : detection method of HandBbox to use to identify person
-        estimation_method_name (str)  : estimation method of HandPoseEstimation to use to identify person
+        estimation_method_name (str) : estimation method of HandPoseEstimation to use to identify person
         reserve_jobs (bool)          : whether to reserve jobs or not
     """
 
     for key in keys:
-        hand_key = key.copy()
+        hand_key = (Video & key).fetch1("KEY")
         bbox_method = (HandBboxMethodLookup & f'detection_method_name="{detection_method_name}"').fetch1(
             "detection_method"
         )
         hand_key['detection_method'] = bbox_method
+        
         # compute the person bbox (requires a method to have inserted the valid bbox)
-        HandBboxMethod.insert(hand_key, skip_duplicates=True, ignore_extra_fields=True)
+        HandBboxMethod.insert([hand_key], skip_duplicates=True, ignore_extra_fields=True)
 
-        HandBbox.populate(hand_key,reserve_jobs=reserve_jobs)
-
+        print('Performing Hand BBox and Estimation for', hand_key)
+        HandBbox.populate([hand_key],reserve_jobs=reserve_jobs)
         estimation_method = (HandPoseEstimationMethodLookup & f'estimation_method_name="{estimation_method_name}"').fetch1("estimation_method")
         hand_key['estimation_method'] = estimation_method
-        HandPoseEstimationMethod.insert(hand_key, skip_duplicates=True, ignore_extra_fields=True)
+        HandPoseEstimationMethod.insert([hand_key], skip_duplicates=True, ignore_extra_fields=True)
 
-        HandPoseEstimation.populate(hand_key, reserve_jobs=reserve_jobs)
+        HandPoseEstimation.populate([hand_key], reserve_jobs=reserve_jobs)

--- a/pose_pipeline/utils/standard_pipelines.py
+++ b/pose_pipeline/utils/standard_pipelines.py
@@ -338,3 +338,36 @@ def blur_videos(keys: Union[Dict, List[Dict]], reserve_jobs: bool = False):
         # handle the case where some of the jobs where reserved
         if len(BottomUpPeople & key) > 0:
             BlurredVideo.populate(key, reserve_jobs=reserve_jobs)
+
+def hand_estimation_pipeline(
+    keys: Union[Dict, List[Dict]],
+    detection_method_name: str = "MoviTopDown",
+    estimation_method_name: str = "RTMPoseHand5",
+    reserve_jobs: bool = False,
+):
+    """
+    Run pipeline on a video to estimate hand keypoints.
+
+    Args:
+        keys (dict)                  : key or keys to compute
+        detection_method_name (str)  : detection method of HandBbox to use to identify person
+        estimation_method_name (str)  : estimation method of HandPoseEstimation to use to identify person
+        reserve_jobs (bool)          : whether to reserve jobs or not
+    """
+
+    for key in keys:
+        hand_key = key.copy()
+        bbox_method = (HandBboxMethodLookup & f'detection_method_name="{detection_method_name}"').fetch1(
+            "detection_method"
+        )
+        hand_key['detection_method'] = bbox_method
+        # compute the person bbox (requires a method to have inserted the valid bbox)
+        HandBboxMethod.insert(hand_key, skip_duplicates=True, ignore_extra_fields=True)
+
+        HandBbox.populate(hand_key,reserve_jobs=reserve_jobs)
+
+        estimation_method = (HandPoseEstimationMethodLookup & f'estimation_method_name="{estimation_method_name}"').fetch1("estimation_method")
+        hand_key['estimation_method'] = estimation_method
+        HandPoseEstimationMethod.insert(hand_key, skip_duplicates=True, ignore_extra_fields=True)
+
+        HandPoseEstimation.populate(hand_key, reserve_jobs=reserve_jobs)

--- a/pose_pipeline/wrappers/hand_estimation.py
+++ b/pose_pipeline/wrappers/hand_estimation.py
@@ -19,6 +19,8 @@ def mmpose_HPE(key, method="RTMPoseHand5"):
 
     if method == "RTMPoseHand5":
         # Define the model config and checkpoint files
+        # pose_config_id = "https://github.com/open-mmlab/mmpose/blob/main/configs/hand_2d_keypoint/rtmpose/hand5/rtmpose-m_8xb256-210e_hand5-256x256.py"
+
         pose_config_id = "rtmpose-m_8xb256-210e_hand5-256x256"
         pose_checkpoint = (
             "rtmpose-m_simcc-hand5_pt-aic-coco_210e-256x256-74fb594_20230320.pth"
@@ -27,8 +29,7 @@ def mmpose_HPE(key, method="RTMPoseHand5"):
         # define the destination folder
         destination = os.path.join(MODEL_DATA_DIR, f"mmpose/{method}/")
 
-        # download the model and checkpoints
-        download(package, [pose_config_id], dest_root=destination)
+        download(package, [pose_config_id], dest_root=destination,check_certificate=False)
 
         # define the model config and checkpoints paths
         pose_model_cfg = os.path.join(destination, f"{pose_config_id}.py")

--- a/pose_pipeline/wrappers/hand_estimation.py
+++ b/pose_pipeline/wrappers/hand_estimation.py
@@ -29,7 +29,7 @@ def mmpose_HPE(key, method="RTMPoseHand5"):
         # define the destination folder
         destination = os.path.join(MODEL_DATA_DIR, f"mmpose/{method}/")
 
-        download(package, [pose_config_id], dest_root=destination,check_certificate=False)
+        download(package, [pose_config_id], dest_root=destination)
 
         # define the model config and checkpoints paths
         pose_model_cfg = os.path.join(destination, f"{pose_config_id}.py")


### PR DESCRIPTION
The following code populates the HandEstimation and HandBBox tables. Currently, the default methods are estimation_method=0  using the RTMPose architecture trained on Hand5 dataset. 

Updates to existing code for sanity checks in capturing keypoint names.