### PR TITLE
Feat/bridging pytorch backend

### DIFF
--- a/pose_pipeline/dj_schema.py
+++ b/pose_pipeline/dj_schema.py
@@ -1,36 +1,67 @@
 """Schema helper that stamps every table with a row-insertion timestamp.
 
-`TimestampedSchema` is a drop-in replacement for `dj.schema`: it behaves exactly like a normal
-DataJoint schema, but when it declares a table it first appends an ``insertion_time`` secondary
-attribute to the table's definition. This gives us a uniform, automatic record of when each row
-was inserted (useful for provenance and for measuring processing time between pipeline stages),
-without having to add the field by hand to every table -- and so that *new* tables can't forget it.
+``TimestampedSchema`` is a drop-in replacement for ``dj.schema``: it behaves exactly like a normal
+DataJoint schema, but when it declares a table it first appends a row-insertion timestamp attribute
+to the table's definition. This gives us a uniform, automatic record of when each row was inserted
+(useful for provenance and for measuring processing time between pipeline stages), without having to
+add the field by hand to every table -- and so that *new* tables can't forget it.
 
 Usage (replaces ``schema = dj.schema("...")``)::
 
     from pose_pipeline.dj_schema import TimestampedSchema
     schema = TimestampedSchema(db_prefix + "pose_pipeline")
 
-Scope: only ``dj.Computed`` / ``dj.Imported`` / ``dj.Manual`` tables are stamped. ``dj.Lookup``
-tables (static config) and ``dj.Part`` tables (inserted with their master) are skipped. A table
-that already declares ``insertion_time`` is left untouched.
+Naming: the attribute is ``<table>_inserted_at`` where ``<table>`` is the table's own snake_case
+name (e.g. ``video_inserted_at``, ``kinematic_reconstruction_inserted_at``). The per-table prefix is
+deliberate: DataJoint refuses to natural-join two expressions that share a *secondary* attribute, so
+a single uniform name like ``insertion_time`` on every table would break ``A * B`` joins between any
+two stamped tables. A name unique to each table keeps joins working. (The only residual case is a
+natural join of two *identically-named* tables from different schemas -- rare and unusual.)
 
-For existing databases the column is added by the one-time migration
-(``scripts/migrate_add_insertion_time.py``); this wrapper covers freshly-declared tables.
+Scope: only ``dj.Computed`` / ``dj.Imported`` / ``dj.Manual`` tables are stamped. ``dj.Lookup``
+tables (static config) and ``dj.Part`` tables (inserted with their master) are skipped. A table that
+already declares its ``<table>_inserted_at`` field is left untouched.
+
+For existing databases the column is added/renamed by the one-time migration
+(``scripts/migrate_add_insertion_time.py`` in each repo); this wrapper covers freshly-declared tables.
 """
 
+import hashlib
 import re
 
 import datajoint as dj
+from datajoint.utils import from_camel_case
 
-# `= CURRENT_TIMESTAMP` -> MySQL `DEFAULT CURRENT_TIMESTAMP` (set once at insert, no ON UPDATE).
-INSERTION_TIME_ATTR = "insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)"
+# DataJoint/MySQL cap attribute names at 64 chars.
+_MAX_ATTR_LEN = 64
+_SUFFIX = "_inserted_at"
+_HASH_LEN = 8  # hex chars of the disambiguating hash used only in the abbreviation fallback
 
 _DIVIDER = re.compile(r"^\s*-{3,}\s*$", re.MULTILINE)
 
 
-def add_insertion_time(cls):
-    """Append an ``insertion_time`` attribute to a table class's ``definition`` (in place).
+def inserted_at_attr(cls):
+    """Return the row-insertion-timestamp attribute name for a table class.
+
+    Normally ``<table>_inserted_at`` (readable). If that would exceed the 64-char attribute limit
+    (only for pathologically long table names), fall back to ``<prefix>_<hash>_inserted_at``: a
+    truncated readable prefix plus a short deterministic hash of the full name, so it stays unique
+    (plain truncation could collide) and still ends in the greppable ``_inserted_at``. This is a
+    pure function -- the migration imports it too, so the code-generated name and the DB column
+    can never diverge.
+    """
+    base = from_camel_case(cls.__name__)
+    field = f"{base}{_SUFFIX}"
+    if len(field) <= _MAX_ATTR_LEN:
+        return field
+    digest = hashlib.sha1(base.encode()).hexdigest()[:_HASH_LEN]
+    keep = _MAX_ATTR_LEN - len(_SUFFIX) - _HASH_LEN - 1  # 1 for the underscore before the hash
+    prefix = base[:keep].rstrip("_")
+    return f"{prefix}_{digest}{_SUFFIX}"
+
+
+def add_inserted_at(cls):
+    """Append a ``<table>_inserted_at`` attribute to a table class's ``definition`` (in place).
 
     Returns the class unchanged if it is a Lookup/Part, is not a table, or already has the field.
     """
@@ -39,19 +70,24 @@ def add_insertion_time(cls):
     if issubclass(cls, dj.Part):
         return cls  # Part tables ride along with their master
     definition = getattr(cls, "definition", None)
-    if not isinstance(definition, str) or "insertion_time" in definition:
-        return cls  # already stamped (e.g. the renamed legacy tables)
+    if not isinstance(definition, str):
+        return cls
+
+    field = inserted_at_attr(cls)
+    assert len(field) <= _MAX_ATTR_LEN, field  # inserted_at_attr guarantees this
+    if field in definition:
+        return cls  # already stamped
 
     body = definition.rstrip()
     if not _DIVIDER.search(body):
         body += "\n    ---"  # all-primary-key table: it has no secondary section yet
-    cls.definition = body + f"\n    {INSERTION_TIME_ATTR}\n    "
+    cls.definition = body + f"\n    {field} = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)\n    "
     return cls
 
 
 class TimestampedSchema(dj.Schema):
-    """A ``dj.Schema`` that stamps every Computed/Imported/Manual table with ``insertion_time``."""
+    """A ``dj.Schema`` that stamps every Computed/Imported/Manual table with ``<table>_inserted_at``."""
 
     def __call__(self, cls, *args, **kwargs):
-        add_insertion_time(cls)
+        add_inserted_at(cls)
         return super().__call__(cls, *args, **kwargs)

--- a/pose_pipeline/dj_schema.py
+++ b/pose_pipeline/dj_schema.py
@@ -1,0 +1,57 @@
+"""Schema helper that stamps every table with a row-insertion timestamp.
+
+`TimestampedSchema` is a drop-in replacement for `dj.schema`: it behaves exactly like a normal
+DataJoint schema, but when it declares a table it first appends an ``insertion_time`` secondary
+attribute to the table's definition. This gives us a uniform, automatic record of when each row
+was inserted (useful for provenance and for measuring processing time between pipeline stages),
+without having to add the field by hand to every table -- and so that *new* tables can't forget it.
+
+Usage (replaces ``schema = dj.schema("...")``)::
+
+    from pose_pipeline.dj_schema import TimestampedSchema
+    schema = TimestampedSchema(db_prefix + "pose_pipeline")
+
+Scope: only ``dj.Computed`` / ``dj.Imported`` / ``dj.Manual`` tables are stamped. ``dj.Lookup``
+tables (static config) and ``dj.Part`` tables (inserted with their master) are skipped. A table
+that already declares ``insertion_time`` is left untouched.
+
+For existing databases the column is added by the one-time migration
+(``scripts/migrate_add_insertion_time.py``); this wrapper covers freshly-declared tables.
+"""
+
+import re
+
+import datajoint as dj
+
+# `= CURRENT_TIMESTAMP` -> MySQL `DEFAULT CURRENT_TIMESTAMP` (set once at insert, no ON UPDATE).
+INSERTION_TIME_ATTR = "insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)"
+
+_DIVIDER = re.compile(r"^\s*-{3,}\s*$", re.MULTILINE)
+
+
+def add_insertion_time(cls):
+    """Append an ``insertion_time`` attribute to a table class's ``definition`` (in place).
+
+    Returns the class unchanged if it is a Lookup/Part, is not a table, or already has the field.
+    """
+    if not (isinstance(cls, type) and issubclass(cls, (dj.Computed, dj.Imported, dj.Manual))):
+        return cls  # Lookup tables and non-tables: skip
+    if issubclass(cls, dj.Part):
+        return cls  # Part tables ride along with their master
+    definition = getattr(cls, "definition", None)
+    if not isinstance(definition, str) or "insertion_time" in definition:
+        return cls  # already stamped (e.g. the renamed legacy tables)
+
+    body = definition.rstrip()
+    if not _DIVIDER.search(body):
+        body += "\n    ---"  # all-primary-key table: it has no secondary section yet
+    cls.definition = body + f"\n    {INSERTION_TIME_ATTR}\n    "
+    return cls
+
+
+class TimestampedSchema(dj.Schema):
+    """A ``dj.Schema`` that stamps every Computed/Imported/Manual table with ``insertion_time``."""
+
+    def __call__(self, cls, *args, **kwargs):
+        add_insertion_time(cls)
+        return super().__call__(cls, *args, **kwargs)

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -12,13 +12,16 @@ import datajoint as dj
 
 from .utils.keypoint_matching import match_keypoints_to_bbox
 from .env import add_path
+from .dj_schema import TimestampedSchema
 
 if "custom" not in dj.config:
     dj.config["custom"] = {}
 
 db_prefix = dj.config["custom"].get("database.prefix", "")
 
-schema = dj.schema(db_prefix + "pose_pipeline")
+# TimestampedSchema auto-adds an `insertion_time` timestamp to every Computed/Imported/Manual
+# table (Lookups/Parts skipped). See pose_pipeline/dj_schema.py.
+schema = TimestampedSchema(db_prefix + "pose_pipeline")
 
 
 @schema
@@ -30,7 +33,7 @@ class Video(dj.Manual):
     ---
     video               : attach@localattach    # datajoint managed video file
     start_time          : timestamp(3)          # time of beginning of video, as accurately as known
-    import_time  = CURRENT_TIMESTAMP : timestamp
+    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     @staticmethod
@@ -174,7 +177,7 @@ class BottomUpPeople(dj.Computed):
     -> BottomUpMethod
     ---
     keypoints                   : longblob
-    timestamp=CURRENT_TIMESTAMP : timestamp    # automatic timestamp
+    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     def make(self, key):
@@ -1448,7 +1451,7 @@ class SkeletonAction(dj.Computed):
     label_map         : longblob
     action_window_len : int
     stride            : int
-    computed_timestamp=CURRENT_TIMESTAMP : timestamp    # automatic timestamp
+    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     # Note: this will likely be refactored with a lookup table in the near future

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -33,7 +33,6 @@ class Video(dj.Manual):
     ---
     video               : attach@localattach    # datajoint managed video file
     start_time          : timestamp(3)          # time of beginning of video, as accurately as known
-    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     @staticmethod
@@ -177,7 +176,6 @@ class BottomUpPeople(dj.Computed):
     -> BottomUpMethod
     ---
     keypoints                   : longblob
-    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     def make(self, key):
@@ -1451,7 +1449,6 @@ class SkeletonAction(dj.Computed):
     label_map         : longblob
     action_window_len : int
     stride            : int
-    insertion_time = CURRENT_TIMESTAMP : timestamp  # row insertion time (auto)
     """
 
     # Note: this will likely be refactored with a lookup table in the near future

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -157,8 +157,6 @@ class BottomUpMethodLookup(dj.Lookup):
 
         # this uses the COCO25 keypoints but in the same order as OpenPose
         {"bottom_up_method_name": "Bridging_OpenPose"},
-        # PyTorch MeTRAbs backend (historical entries above are the TF backend)
-        {"bottom_up_method_name": "Bridging_OpenPose_pt"},
     ]
 
 
@@ -226,7 +224,7 @@ class BottomUpPeople(dj.Computed):
 
             key["keypoints"] = mmpose_bottom_up(key)
 
-        elif key["bottom_up_method_name"] in ("Bridging_OpenPose", "Bridging_OpenPose_pt"):
+        elif key["bottom_up_method_name"] == "Bridging_OpenPose":
             from .wrappers.bridging import filter_skeleton, normalized_joint_name_dictionary, noise_to_conf
             assert BottomUpBridging & key, f"Bridging not computed: {key}"
 
@@ -459,9 +457,7 @@ class BlurredVideo(dj.Computed):
         from pose_pipeline.utils.visualization import video_overlay
 
         video = Video.get_robust_reader(key, return_cap=False)
-        keypoints = (
-            BottomUpPeople & key & 'bottom_up_method_name in ("Bridging_OpenPose", "Bridging_OpenPose_pt")'
-        ).fetch1("keypoints")
+        keypoints = (BottomUpPeople & key & 'bottom_up_method_name="Bridging_OpenPose"').fetch1("keypoints")
 
         def overlay_callback(image, idx):
             image = image.copy()
@@ -1049,16 +1045,6 @@ class TopDownMethodLookup(dj.Lookup):
         {"top_down_method": 19, "top_down_method_name": "Bridging_ExtDetector_bml_movi_87"},
         {"top_down_method": 20, "top_down_method_name": "Bridging_ExtDetector_smpl+head_30"},
         {"top_down_method": 21, "top_down_method_name": "Bridging_ExtDetector_smplx_42"},
-        # PyTorch MeTRAbs backend (…_pt). Same algorithm/weights as the TF methods above;
-        # new processing uses these so historical (TF) entries stay distinct.
-        {"top_down_method": 40, "top_down_method_name": "Bridging_COCO_25_pt"},
-        {"top_down_method": 41, "top_down_method_name": "Bridging_bml_movi_87_pt"},
-        {"top_down_method": 42, "top_down_method_name": "Bridging_smpl+head_30_pt"},
-        {"top_down_method": 43, "top_down_method_name": "Bridging_smplx_42_pt"},
-        {"top_down_method": 44, "top_down_method_name": "Bridging_ExtDetector_COCO_25_pt"},
-        {"top_down_method": 45, "top_down_method_name": "Bridging_ExtDetector_bml_movi_87_pt"},
-        {"top_down_method": 46, "top_down_method_name": "Bridging_ExtDetector_smpl+head_30_pt"},
-        {"top_down_method": 47, "top_down_method_name": "Bridging_ExtDetector_smplx_42_pt"},
         {"top_down_method": 30, "top_down_method_name": "Sapiens_0.3b_Goliath"},
         {"top_down_method": 31, "top_down_method_name": "Sapiens_0.6b_Goliath"},
         {"top_down_method": 32, "top_down_method_name": "Sapiens_1b_Goliath"},
@@ -1101,10 +1087,6 @@ class TopDownPerson(dj.Computed):
         original_key = key.copy()
 
         method_name = (TopDownMethodLookup & key).fetch1("top_down_method_name")
-        # PyTorch bridging variants ("Bridging_..._pt") share the same code path as the historical
-        # TF methods; normalize the suffix for dispatch (the stored entry keeps its own method id).
-        if method_name.startswith("Bridging_") and method_name.endswith("_pt"):
-            method_name = method_name[: -len("_pt")]
         if method_name == "MMPose":
             from .wrappers.mmpose import mmpose_top_down_person
 
@@ -1385,9 +1367,6 @@ class TopDownPerson(dj.Computed):
 
     @staticmethod
     def joint_names(method="MMPose", normalize=True):
-        # PyTorch bridging variants share joint definitions with the historical TF methods.
-        if method.startswith("Bridging_") and method.endswith("_pt"):
-            method = method[: -len("_pt")]
         if method == "OpenPose":
             return OpenPosePerson.joint_names()
         elif method == "Bridging_COCO_25":
@@ -1557,12 +1536,6 @@ class LiftingMethodLookup(dj.Lookup):
         {"lifting_method": 19, "lifting_method_name": "Bridging_ExtDetector_bml_movi_87"},
         {"lifting_method": 20, "lifting_method_name": "Bridging_ExtDetector_smpl+head_30"},
         {"lifting_method": 21, "lifting_method_name": "Bridging_ExtDetector_smplx_42"},
-        # PyTorch MeTRAbs backend (…_pt). Same algorithm/weights as the TF methods above;
-        # new processing uses these so historical (TF) entries stay distinct.
-        {"lifting_method": 40, "lifting_method_name": "Bridging_COCO_25_pt"},
-        {"lifting_method": 41, "lifting_method_name": "Bridging_bml_movi_87_pt"},
-        {"lifting_method": 42, "lifting_method_name": "Bridging_smpl+head_30_pt"},
-        {"lifting_method": 43, "lifting_method_name": "Bridging_smplx_42_pt"},
         {"lifting_method": 34, "lifting_method_name": "Sam3dBody_with_hands2"},
         {"lifting_method": 35, "lifting_method_name": "Sam3dBody_movi87"},
         {"lifting_method": 36, "lifting_method_name": "Sam3dBody_ideal"},
@@ -1612,7 +1585,7 @@ class LiftingPerson(dj.Computed):
 
             results = process_poseaug(key)
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_COCO_25", "Bridging_COCO_25_pt"):
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_COCO_25":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
 
@@ -1623,7 +1596,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image(key, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :3], "keypoints_valid": keypoints3d[:, :, -1] > 0.5}
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_bml_movi_87", "Bridging_bml_movi_87_pt"):
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_bml_movi_87":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou
@@ -1668,7 +1641,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image3d(key, keypoints2d, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :], "keypoints_valid": keypoints3d[:, :, -1] > 0.5} # i am giving myself the keypoint noise here too
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_smpl+head_30", "Bridging_smpl+head_30_pt"):
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_smpl+head_30":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou
@@ -1707,7 +1680,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image3d(key, keypoints2d, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :], "keypoints_valid": keypoints3d[:, :, -1] > 0.5} # i am giving myself the keypoint noise here too
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_smplx_42", "Bridging_smplx_42_pt"):
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_smplx_42":
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou
@@ -2397,7 +2370,7 @@ class HandBbox(dj.Computed):
         ) == "MoviTopDown":
             from pose_pipeline.wrappers.hand_bbox import make_bbox_from_keypoints
 
-            keypoints = (TopDownPerson & key & "top_down_method in (12, 41)").fetch1("keypoints")
+            keypoints = (TopDownPerson & key & "top_down_method=12").fetch1("keypoints")
             num_boxes, bboxes = make_bbox_from_keypoints(
                 keypoints,
                 method="movi",

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -2397,7 +2397,7 @@ class HandBbox(dj.Computed):
         ) == "MoviTopDown":
             from pose_pipeline.wrappers.hand_bbox import make_bbox_from_keypoints
 
-            keypoints = (TopDownPerson & key & "top_down_method=12").fetch1("keypoints")
+            keypoints = (TopDownPerson & key & "top_down_method in (12, 41)").fetch1("keypoints")
             num_boxes, bboxes = make_bbox_from_keypoints(
                 keypoints,
                 method="movi",

--- a/pose_pipeline/pipeline.py
+++ b/pose_pipeline/pipeline.py
@@ -157,6 +157,8 @@ class BottomUpMethodLookup(dj.Lookup):
 
         # this uses the COCO25 keypoints but in the same order as OpenPose
         {"bottom_up_method_name": "Bridging_OpenPose"},
+        # PyTorch MeTRAbs backend (historical entries above are the TF backend)
+        {"bottom_up_method_name": "Bridging_OpenPose_pt"},
     ]
 
 
@@ -224,7 +226,7 @@ class BottomUpPeople(dj.Computed):
 
             key["keypoints"] = mmpose_bottom_up(key)
 
-        elif key["bottom_up_method_name"] == "Bridging_OpenPose":
+        elif key["bottom_up_method_name"] in ("Bridging_OpenPose", "Bridging_OpenPose_pt"):
             from .wrappers.bridging import filter_skeleton, normalized_joint_name_dictionary, noise_to_conf
             assert BottomUpBridging & key, f"Bridging not computed: {key}"
 
@@ -457,7 +459,9 @@ class BlurredVideo(dj.Computed):
         from pose_pipeline.utils.visualization import video_overlay
 
         video = Video.get_robust_reader(key, return_cap=False)
-        keypoints = (BottomUpPeople & key & 'bottom_up_method_name="Bridging_OpenPose"').fetch1("keypoints")
+        keypoints = (
+            BottomUpPeople & key & 'bottom_up_method_name in ("Bridging_OpenPose", "Bridging_OpenPose_pt")'
+        ).fetch1("keypoints")
 
         def overlay_callback(image, idx):
             image = image.copy()
@@ -1045,6 +1049,16 @@ class TopDownMethodLookup(dj.Lookup):
         {"top_down_method": 19, "top_down_method_name": "Bridging_ExtDetector_bml_movi_87"},
         {"top_down_method": 20, "top_down_method_name": "Bridging_ExtDetector_smpl+head_30"},
         {"top_down_method": 21, "top_down_method_name": "Bridging_ExtDetector_smplx_42"},
+        # PyTorch MeTRAbs backend (…_pt). Same algorithm/weights as the TF methods above;
+        # new processing uses these so historical (TF) entries stay distinct.
+        {"top_down_method": 40, "top_down_method_name": "Bridging_COCO_25_pt"},
+        {"top_down_method": 41, "top_down_method_name": "Bridging_bml_movi_87_pt"},
+        {"top_down_method": 42, "top_down_method_name": "Bridging_smpl+head_30_pt"},
+        {"top_down_method": 43, "top_down_method_name": "Bridging_smplx_42_pt"},
+        {"top_down_method": 44, "top_down_method_name": "Bridging_ExtDetector_COCO_25_pt"},
+        {"top_down_method": 45, "top_down_method_name": "Bridging_ExtDetector_bml_movi_87_pt"},
+        {"top_down_method": 46, "top_down_method_name": "Bridging_ExtDetector_smpl+head_30_pt"},
+        {"top_down_method": 47, "top_down_method_name": "Bridging_ExtDetector_smplx_42_pt"},
         {"top_down_method": 30, "top_down_method_name": "Sapiens_0.3b_Goliath"},
         {"top_down_method": 31, "top_down_method_name": "Sapiens_0.6b_Goliath"},
         {"top_down_method": 32, "top_down_method_name": "Sapiens_1b_Goliath"},
@@ -1087,6 +1101,10 @@ class TopDownPerson(dj.Computed):
         original_key = key.copy()
 
         method_name = (TopDownMethodLookup & key).fetch1("top_down_method_name")
+        # PyTorch bridging variants ("Bridging_..._pt") share the same code path as the historical
+        # TF methods; normalize the suffix for dispatch (the stored entry keeps its own method id).
+        if method_name.startswith("Bridging_") and method_name.endswith("_pt"):
+            method_name = method_name[: -len("_pt")]
         if method_name == "MMPose":
             from .wrappers.mmpose import mmpose_top_down_person
 
@@ -1367,6 +1385,9 @@ class TopDownPerson(dj.Computed):
 
     @staticmethod
     def joint_names(method="MMPose", normalize=True):
+        # PyTorch bridging variants share joint definitions with the historical TF methods.
+        if method.startswith("Bridging_") and method.endswith("_pt"):
+            method = method[: -len("_pt")]
         if method == "OpenPose":
             return OpenPosePerson.joint_names()
         elif method == "Bridging_COCO_25":
@@ -1536,6 +1557,12 @@ class LiftingMethodLookup(dj.Lookup):
         {"lifting_method": 19, "lifting_method_name": "Bridging_ExtDetector_bml_movi_87"},
         {"lifting_method": 20, "lifting_method_name": "Bridging_ExtDetector_smpl+head_30"},
         {"lifting_method": 21, "lifting_method_name": "Bridging_ExtDetector_smplx_42"},
+        # PyTorch MeTRAbs backend (…_pt). Same algorithm/weights as the TF methods above;
+        # new processing uses these so historical (TF) entries stay distinct.
+        {"lifting_method": 40, "lifting_method_name": "Bridging_COCO_25_pt"},
+        {"lifting_method": 41, "lifting_method_name": "Bridging_bml_movi_87_pt"},
+        {"lifting_method": 42, "lifting_method_name": "Bridging_smpl+head_30_pt"},
+        {"lifting_method": 43, "lifting_method_name": "Bridging_smplx_42_pt"},
         {"lifting_method": 34, "lifting_method_name": "Sam3dBody_with_hands2"},
         {"lifting_method": 35, "lifting_method_name": "Sam3dBody_movi87"},
         {"lifting_method": 36, "lifting_method_name": "Sam3dBody_ideal"},
@@ -1585,7 +1612,7 @@ class LiftingPerson(dj.Computed):
 
             results = process_poseaug(key)
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_COCO_25":
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_COCO_25", "Bridging_COCO_25_pt"):
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image
 
@@ -1596,7 +1623,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image(key, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :3], "keypoints_valid": keypoints3d[:, :, -1] > 0.5}
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_bml_movi_87":
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_bml_movi_87", "Bridging_bml_movi_87_pt"):
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou
@@ -1641,7 +1668,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image3d(key, keypoints2d, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :], "keypoints_valid": keypoints3d[:, :, -1] > 0.5} # i am giving myself the keypoint noise here too
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_smpl+head_30":
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_smpl+head_30", "Bridging_smpl+head_30_pt"):
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou
@@ -1680,7 +1707,7 @@ class LiftingPerson(dj.Computed):
             keypoints3d = keypoints_filter_clipped_image3d(key, keypoints2d, keypoints3d)
             results = {"keypoints_3d": keypoints3d[:, :, :], "keypoints_valid": keypoints3d[:, :, -1] > 0.5} # i am giving myself the keypoint noise here too
 
-        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") == "Bridging_smplx_42":
+        elif (LiftingMethodLookup & key).fetch1("lifting_method_name") in ("Bridging_smplx_42", "Bridging_smplx_42_pt"):
             from pose_pipeline.wrappers.bridging import filter_skeleton
             from pose_pipeline.utils.keypoints import keypoints_filter_clipped_image,keypoints_filter_clipped_image3d
             from pose_pipeline.utils.keypoint_matching import compute_iou

--- a/pose_pipeline/utils/standard_pipelines.py
+++ b/pose_pipeline/utils/standard_pipelines.py
@@ -110,8 +110,8 @@ def top_down_pipeline(
 def lifting_pipeline(
     key,
     tracking_method_name: str = "MMDet_deepsort",
-    top_down_method_name: str = "Bridging_bml_movi_87_pt",
-    lifting_method_name: str = "Bridging_bml_movi_87_pt",
+    top_down_method_name: str = "Bridging_bml_movi_87",
+    lifting_method_name: str = "Bridging_bml_movi_87",
     reserve_jobs: bool = False,
 ):
     """
@@ -238,12 +238,7 @@ def bottomup_to_topdown(
             PersonBbox & key & (TrackingBboxMethodLookup & {"tracking_method_name": tracking_method_name})
         ).fetch1("KEY")
 
-        if bottom_up_method_name in [
-            "Bridging_COCO_25",
-            "Bridging_bml_movi_87",
-            "Bridging_COCO_25_pt",
-            "Bridging_bml_movi_87_pt",
-        ]:
+        if bottom_up_method_name in ["Bridging_COCO_25", "Bridging_bml_movi_87"]:
             from pose_pipeline.pipeline import BottomUpBridging, BottomUpBridgingPerson
 
             BottomUpBridging.populate(key, reserve_jobs=reserve_jobs)
@@ -294,14 +289,7 @@ def bottom_up_pipeline(
     for key in keys:
         key = key.copy()
 
-        if bottom_up_method_name in [
-            "Bridging_COCO_25",
-            "Bridging_bml_movi_87",
-            "Bridging_OpenPose",
-            "Bridging_COCO_25_pt",
-            "Bridging_bml_movi_87_pt",
-            "Bridging_OpenPose_pt",
-        ]:
+        if bottom_up_method_name in ["Bridging_COCO_25", "Bridging_bml_movi_87", "Bridging_OpenPose"]:
             from pose_pipeline.pipeline import BottomUpBridging
 
             print(f"Computing {bottom_up_method_name} for {key}")
@@ -345,7 +333,7 @@ def blur_videos(keys: Union[Dict, List[Dict]], reserve_jobs: bool = False):
         print(key)
 
         VideoInfo.populate(key, reserve_jobs=reserve_jobs)  # required for various downstream tasks
-        bottom_up_pipeline(key, bottom_up_method_name="Bridging_OpenPose_pt", reserve_jobs=reserve_jobs)
+        bottom_up_pipeline(key, bottom_up_method_name="Bridging_OpenPose", reserve_jobs=reserve_jobs)
 
         # handle the case where some of the jobs where reserved
         if len(BottomUpPeople & key) > 0:

--- a/pose_pipeline/utils/standard_pipelines.py
+++ b/pose_pipeline/utils/standard_pipelines.py
@@ -110,8 +110,8 @@ def top_down_pipeline(
 def lifting_pipeline(
     key,
     tracking_method_name: str = "MMDet_deepsort",
-    top_down_method_name: str = "Bridging_bml_movi_87",
-    lifting_method_name: str = "Bridging_bml_movi_87",
+    top_down_method_name: str = "Bridging_bml_movi_87_pt",
+    lifting_method_name: str = "Bridging_bml_movi_87_pt",
     reserve_jobs: bool = False,
 ):
     """
@@ -238,7 +238,12 @@ def bottomup_to_topdown(
             PersonBbox & key & (TrackingBboxMethodLookup & {"tracking_method_name": tracking_method_name})
         ).fetch1("KEY")
 
-        if bottom_up_method_name in ["Bridging_COCO_25", "Bridging_bml_movi_87"]:
+        if bottom_up_method_name in [
+            "Bridging_COCO_25",
+            "Bridging_bml_movi_87",
+            "Bridging_COCO_25_pt",
+            "Bridging_bml_movi_87_pt",
+        ]:
             from pose_pipeline.pipeline import BottomUpBridging, BottomUpBridgingPerson
 
             BottomUpBridging.populate(key, reserve_jobs=reserve_jobs)
@@ -289,7 +294,14 @@ def bottom_up_pipeline(
     for key in keys:
         key = key.copy()
 
-        if bottom_up_method_name in ["Bridging_COCO_25", "Bridging_bml_movi_87", "Bridging_OpenPose"]:
+        if bottom_up_method_name in [
+            "Bridging_COCO_25",
+            "Bridging_bml_movi_87",
+            "Bridging_OpenPose",
+            "Bridging_COCO_25_pt",
+            "Bridging_bml_movi_87_pt",
+            "Bridging_OpenPose_pt",
+        ]:
             from pose_pipeline.pipeline import BottomUpBridging
 
             print(f"Computing {bottom_up_method_name} for {key}")
@@ -333,7 +345,7 @@ def blur_videos(keys: Union[Dict, List[Dict]], reserve_jobs: bool = False):
         print(key)
 
         VideoInfo.populate(key, reserve_jobs=reserve_jobs)  # required for various downstream tasks
-        bottom_up_pipeline(key, bottom_up_method_name="Bridging_OpenPose", reserve_jobs=reserve_jobs)
+        bottom_up_pipeline(key, bottom_up_method_name="Bridging_OpenPose_pt", reserve_jobs=reserve_jobs)
 
         # handle the case where some of the jobs where reserved
         if len(BottomUpPeople & key) > 0:

--- a/pose_pipeline/wrappers/bridging.py
+++ b/pose_pipeline/wrappers/bridging.py
@@ -42,6 +42,10 @@ def make_coco_25(model):
 # TF SavedModel; the PyTorch weights are converted from that TF checkpoint.
 METRABS_PT_MODEL_NAME = "metrabs_eff2l_384px_800k_28ds_pytorch"
 METRABS_PT_URLS = [
+    # Org-mirrored release asset (stable; create via `gh release create` — see README).
+    "https://github.com/IntelligentSensingAndRehabilitation/metrabs/releases/download/"
+    "weights-eff2l-v0.2/metrabs_eff2l_384px_800k_28ds_pytorch.tar.gz",
+    # Upstream mirrors (fallback).
     "https://bit.ly/metrabs_l_pt",
     "https://omnomnom.vision.rwth-aachen.de/data/metrabs/metrabs_eff2l_384px_800k_28ds_pytorch.tar.gz",
 ]

--- a/pose_pipeline/wrappers/bridging.py
+++ b/pose_pipeline/wrappers/bridging.py
@@ -3,6 +3,7 @@ import os
 
 import cv2
 import numpy as np
+import torch
 
 from pose_pipeline import Video
 
@@ -37,39 +38,100 @@ def make_coco_25(model):
     return model
 
 
+# PyTorch MeTRAbs (SRALab-CBM fork of isarandi/metrabs). Same eff2l model as the former
+# TF SavedModel; the PyTorch weights are converted from that TF checkpoint.
+METRABS_PT_MODEL_NAME = "metrabs_eff2l_384px_800k_28ds_pytorch"
+METRABS_PT_URLS = [
+    "https://bit.ly/metrabs_l_pt",
+    "https://omnomnom.vision.rwth-aachen.de/data/metrabs/metrabs_eff2l_384px_800k_28ds_pytorch.tar.gz",
+]
+
+
+def _ensure_metrabs_model(model_dir):
+    """Auto-download + extract the PyTorch MeTRAbs model archive if not already present.
+
+    Mirrors the old TFHub auto-download so users don't need a manual setup step.
+    """
+    if os.path.exists(os.path.join(model_dir, "ckpt.pt")):
+        return
+    import tarfile
+    import tempfile
+    import urllib.request
+
+    parent = os.path.dirname(model_dir)
+    os.makedirs(parent, exist_ok=True)
+    for url in METRABS_PT_URLS:
+        try:
+            print(f"Downloading MeTRAbs (PyTorch) model from {url} ...")
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
+                urllib.request.urlretrieve(url, tmp.name)
+                with tarfile.open(tmp.name, mode="r:gz") as tar:
+                    tar.extractall(parent)
+            return
+        except Exception as e:  # noqa: BLE001 - try the next mirror
+            print(f"Failed to download from {url}: {e}")
+    raise RuntimeError("Failed to download MeTRAbs PyTorch model from all URLs")
+
+
+def _load_pytorch_metrabs(model_dir):
+    """Build the crop model + multi-person estimator from a downloaded model directory."""
+    import simplepyutils as spu
+
+    import metrabs_pytorch.backbones.efficientnet as effnet_pt
+    import metrabs_pytorch.models.metrabs as metrabs_pt
+    from metrabs_pytorch.multiperson import multiperson_model
+    from metrabs_pytorch.util import get_config
+    from posepile.joint_info import JointInfo
+
+    get_config(os.path.join(model_dir, "config.yaml"))
+    cfg = get_config()
+    ji = np.load(os.path.join(model_dir, "joint_info.npz"))
+    joint_info = JointInfo(ji["joint_names"], ji["joint_edges"])
+    backbone = torch.nn.Sequential(
+        effnet_pt.PreprocLayer(),
+        getattr(effnet_pt, f"efficientnet_v2_{cfg.efficientnet_size}")().features,
+    )
+    crop_model = metrabs_pt.Metrabs(backbone, joint_info)
+    crop_model.eval()
+    crop_model((torch.zeros((1, 3, cfg.proc_side, cfg.proc_side)), torch.eye(3)[np.newaxis]))
+    crop_model.load_state_dict(torch.load(os.path.join(model_dir, "ckpt.pt")))
+    skeleton_infos = spu.load_pickle(os.path.join(model_dir, "skeleton_infos.pkl"))
+    joint_transform = np.load(os.path.join(model_dir, "joint_transform_matrix.npy"))
+    with torch.device("cuda"):
+        model = multiperson_model.Pose3dEstimator(
+            crop_model.cuda(), skeleton_infos, joint_transform
+        ).cuda()
+
+    # Expose skeleton metadata in the same numpy/bytes format the TF SavedModel used, so
+    # make_coco_25 / filter_skeleton / get_joint_names / downstream keep working unchanged.
+    model.per_skeleton_joint_names = {
+        k: np.array([n.encode("utf-8") for n in v["names"]]) for k, v in skeleton_infos.items()
+    }
+    model.per_skeleton_indices = {
+        k: np.array(v["indices"], dtype=np.int64) for k, v in skeleton_infos.items()
+    }
+    model.per_skeleton_joint_edges = {
+        k: np.array(v["edges"], dtype=np.int64) for k, v in skeleton_infos.items()
+    }
+    return model
+
+
 def get_model():
     if get_model.model is None:
-        import tensorflow_hub as hub
+        from pose_pipeline import MODEL_DATA_DIR
 
-        from pose_pipeline import tensorflow_memory_limit
+        # posepile.paths reads DATA_ROOT at import time; inference doesn't use datasets, so an
+        # (empty) directory is enough. Set it before importing any metrabs_pytorch/posepile code.
+        data_root = os.environ.setdefault("DATA_ROOT", os.path.join(MODEL_DATA_DIR, "posepile_data_root"))
+        os.makedirs(data_root, exist_ok=True)
 
-        tensorflow_memory_limit()
+        model_dir = os.path.join(MODEL_DATA_DIR, METRABS_PT_MODEL_NAME)
+        _ensure_metrabs_model(model_dir)
 
-        METRABS_URLS = [
-            "https://bit.ly/metrabs_l",
-            "https://omnomnom.vision.rwth-aachen.de/data/metrabs/metrabs_eff2l_y4_384px_800k_28ds.tar.gz",
-        ]
-
-        print("Loading MeTRAbs Model...")
-        model_cache = os.environ.get("TFHUB_CACHE_DIR")
-        print(f"Model cached in: {model_cache}")
-        for url in METRABS_URLS:
-            try:
-                model = hub.load(url)
-                break
-            except Exception as e:
-                print(f"Failed to load from {url}: {e}")
-        else:
-            raise RuntimeError("Failed to load MeTRAbs model from all URLs")
-        print("MeTRAbs Model Loaded")
-        model.per_skeleton_joint_names = {
-            k: v.numpy() for k, v in model.per_skeleton_joint_names.items()
-        }
-        model.per_skeleton_indices = {
-            k: v.numpy() for k, v in model.per_skeleton_indices.items()
-        }
-
+        print("Loading MeTRAbs (PyTorch) model...")
+        model = _load_pytorch_metrabs(model_dir)
         model = make_coco_25(model)
+        print("MeTRAbs (PyTorch) model loaded")
 
         get_model.model = model
 
@@ -138,6 +200,7 @@ def bridging_formats_bottom_up(key, model=None, skeleton=""):
 
     video_length = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
+    n_joints = model.per_skeleton_indices[skeleton].shape[0]
     boxes = []
     keypoints2d = []
     keypoints3d = []
@@ -147,23 +210,34 @@ def bridging_formats_bottom_up(key, model=None, skeleton=""):
         assert ret and frame is not None
 
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frame_t = torch.from_numpy(np.ascontiguousarray(frame.transpose(2, 0, 1))).cuda()
 
-        pred = model.detect_poses(
-            frame,
-            skeleton=skeleton,
-            num_aug=10,
-            average_aug=False,
-            detector_flip_aug=True,
-            detector_threshold=0.1,
-        )
+        try:
+            with torch.inference_mode(), torch.device("cuda"):
+                pred = model.detect_poses(
+                    frame_t,
+                    skeleton=skeleton,
+                    num_aug=10,
+                    average_aug=False,
+                    detector_flip_aug=True,
+                    detector_threshold=0.1,
+                )
+            poses3d_np = pred["poses3d"].cpu().numpy()
+            boxes.append(pred["boxes"].cpu().numpy())
+            keypoints2d.append(np.mean(pred["poses2d"].cpu().numpy(), axis=1))
+            keypoints3d.append(np.mean(poses3d_np, axis=1))
+            keypoint_noises.append(augmentation_noise(poses3d_np))
+            del pred, poses3d_np
+        except RuntimeError as e:
+            # No person detected in this frame -> detector returns no boxes (empty torch.cat).
+            if "non-empty list" not in str(e):
+                raise
+            boxes.append(np.zeros((0, 5)))
+            keypoints2d.append(np.zeros((0, n_joints, 2)))
+            keypoints3d.append(np.zeros((0, n_joints, 3)))
+            keypoint_noises.append(np.zeros((0, n_joints)))
 
-        poses3d_np = pred["poses3d"].numpy()
-        boxes.append(pred["boxes"].numpy())
-        keypoints2d.append(np.mean(pred["poses2d"].numpy(), axis=1))
-        keypoints3d.append(np.mean(poses3d_np, axis=1))
-        keypoint_noises.append(augmentation_noise(poses3d_np))
-
-        del pred, frame, poses3d_np
+        del frame, frame_t
         if frame_idx % 100 == 0:
             gc.collect()
 
@@ -198,7 +272,6 @@ def bridging_formats_with_external_bbox(
     Returns:
         dict with keys: boxes, keypoints2d, keypoints3d, keypoint_noise
     """
-    import tensorflow as tf
     from tqdm import tqdm
 
     if model is None:
@@ -227,18 +300,21 @@ def bridging_formats_with_external_bbox(
             keypoint_noises.append(np.zeros((1, n_joints)))
             continue
 
-        bbox = tf.convert_to_tensor([external_bboxes[frame_idx]], dtype=tf.float32)
-        pred = model.estimate_poses(
-            frame, bbox, skeleton=skeleton, num_aug=10, average_aug=False
-        )
+        bbox_np = np.asarray([external_bboxes[frame_idx]], dtype=np.float32)  # (1, 4)
+        bbox_t = torch.from_numpy(bbox_np).cuda()
+        frame_t = torch.from_numpy(np.ascontiguousarray(frame.transpose(2, 0, 1))).cuda()
+        with torch.inference_mode(), torch.device("cuda"):
+            pred = model.estimate_poses(
+                frame_t, bbox_t, skeleton=skeleton, num_aug=10, average_aug=False
+            )
 
-        poses3d_np = pred["poses3d"].numpy()
-        boxes.append(bbox.numpy())
-        keypoints2d.append(np.mean(pred["poses2d"].numpy(), axis=1))
+        poses3d_np = pred["poses3d"].cpu().numpy()
+        boxes.append(bbox_np)
+        keypoints2d.append(np.mean(pred["poses2d"].cpu().numpy(), axis=1))
         keypoints3d.append(np.mean(poses3d_np, axis=1))
         keypoint_noises.append(augmentation_noise(poses3d_np))
 
-        del pred, frame, poses3d_np
+        del pred, frame, frame_t, poses3d_np
         if frame_idx % 100 == 0:
             gc.collect()
 

--- a/pose_pipeline/wrappers/bridging.py
+++ b/pose_pipeline/wrappers/bridging.py
@@ -3,9 +3,12 @@ import os
 
 import cv2
 import numpy as np
-import torch
 
 from pose_pipeline import Video
+
+# torch is imported lazily inside the 3 functions that need it (_load_pytorch_metrabs and the two
+# bridging_formats_* runners), so the pure-numpy helpers (filter_skeleton, noise_to_conf, etc.)
+# can be imported without pulling in torch.
 
 # supported formats are
 # 'smpl_24', 'h36m_17', 'h36m_25', 'mpi_inf_3dhp_17', 'mpi_inf_3dhp_28', 'coco_19', 'sailvos_26', 'gpa_34', 'aspset_17',
@@ -79,6 +82,8 @@ def _ensure_metrabs_model(model_dir):
 
 def _load_pytorch_metrabs(model_dir):
     """Build the crop model + multi-person estimator from a downloaded model directory."""
+    import torch
+
     import simplepyutils as spu
 
     import metrabs_pytorch.backbones.efficientnet as effnet_pt
@@ -194,6 +199,8 @@ def noise_to_conf(x, half_val=200, sharpness=50):
 
 def bridging_formats_bottom_up(key, model=None, skeleton=""):
 
+    import torch
+
     if model is None:
         model = get_model()
 
@@ -276,6 +283,8 @@ def bridging_formats_with_external_bbox(
     Returns:
         dict with keys: boxes, keypoints2d, keypoints3d, keypoint_noise
     """
+    import torch
+
     from tqdm import tqdm
 
     if model is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = ["pytest","ipython","ipywidgets","ipympl","seaborn"]
 # MeTRAbs "bridging" pose estimation (PyTorch). The isarandi packages are git-only (not on
 # PyPI); metrabs is our fork with the inference fixes. Weights auto-download on first use.
 bridging = [
-    "metrabs-pytorch @ git+https://github.com/IntelligentSensingAndRehabilitation/metrabs@pytorch-inference-fixes",
+    "metrabs-pytorch @ git+https://github.com/IntelligentSensingAndRehabilitation/metrabs@v0.1-pytorch-inference",
     "posepile @ git+https://github.com/isarandi/posepile",
     "simplepyutils @ git+https://github.com/isarandi/simplepyutils",
     "cameralib @ git+https://github.com/isarandi/cameralib",
@@ -62,6 +62,6 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [[tool.uv.index]]
-name = "pytorch-cu124"
-url = "https://download.pytorch.org/whl/cu124"
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ dependencies = [
     "openmim>=0.3.9",
     "pycocotools>=2.0.8",
     "pyrender>=0.1.45",
-    "tensorflow[and-cuda]>=2.14.0",
-    "tensorflow-hub",
-    "tf-keras>=2.18.0",
     "torch>=2.0.1",
     "torchaudio>=2.0.2",
     "torchvision>=0.15.2"
@@ -28,6 +25,16 @@ opencv-contrib = ["opencv-contrib-python>=4.0.0"]
 build = ["setuptools>70", "pip>22"]
 compile = ["chumpy>0.4"]
 dev = ["pytest","ipython","ipywidgets","ipympl","seaborn"]
+# MeTRAbs "bridging" pose estimation (PyTorch). The isarandi packages are git-only (not on
+# PyPI); metrabs is our fork with the inference fixes. Weights auto-download on first use.
+bridging = [
+    "metrabs-pytorch @ git+https://github.com/IntelligentSensingAndRehabilitation/metrabs@pytorch-inference-fixes",
+    "posepile @ git+https://github.com/isarandi/posepile",
+    "simplepyutils @ git+https://github.com/isarandi/simplepyutils",
+    "cameralib @ git+https://github.com/isarandi/cameralib",
+    "ultralytics",
+    "hydra-core",
+]
 
 [tool.uv]
 no-build-isolation-package = ["chumpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ markers = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [[tool.uv.index]]
 name = "pytorch-cu124"
 url = "https://download.pytorch.org/whl/cu124"

--- a/scripts/migrate_add_insertion_time.py
+++ b/scripts/migrate_add_insertion_time.py
@@ -1,0 +1,76 @@
+"""One-time migration to add `insertion_time` to existing pose_pipeline tables.
+
+Pairs with the `TimestampedSchema` change (pose_pipeline/dj_schema.py), which stamps *new*
+tables automatically. This migration updates the *existing* database:
+
+  - ADD    a `insertion_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP` column to every
+           Computed/Imported/Manual table that doesn't have one (Lookups/Parts skipped).
+           Existing rows get the migration time; new rows get their insert time.
+  - RENAME the 3 legacy timestamp fields to `insertion_time` (preserving the *real* historical
+           timestamps those tables already recorded): Video.import_time,
+           BottomUpPeople.timestamp, SkeletonAction.computed_timestamp.
+
+Idempotent (safe to re-run). DRY-RUN by default; pass --apply to execute. Requires WRITE creds.
+
+    python scripts/migrate_add_insertion_time.py            # dry-run: show what would change
+    python scripts/migrate_add_insertion_time.py --apply    # execute
+"""
+import argparse
+
+import datajoint as dj
+
+# tables whose existing timestamp field is RENAMED (keeps real historical values, not migration time)
+RENAMES = {
+    "Video": "import_time",
+    "BottomUpPeople": "timestamp",
+    "SkeletonAction": "computed_timestamp",
+}
+COLDEF = "`insertion_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="execute the ALTERs (default: dry-run)")
+    args = ap.parse_args()
+
+    import pose_pipeline.pipeline as P
+
+    conn = dj.conn()
+    db = P.schema.database
+
+    tables = [
+        obj
+        for obj in vars(P).values()
+        if isinstance(obj, type)
+        and issubclass(obj, (dj.Computed, dj.Imported, dj.Manual))
+        and not issubclass(obj, dj.Part)
+        and getattr(obj, "database", None) == db
+    ]
+    print(f"schema: {db} | {len(tables)} Computed/Imported/Manual tables\n")
+
+    add = rename = skip = 0
+    for t in sorted(tables, key=lambda c: c.__name__):
+        names = t.heading.names
+        ftn = t.full_table_name
+        if "insertion_time" in names:
+            print(f"  skip    {t.__name__:30s} (already has insertion_time)")
+            skip += 1
+            continue
+        legacy = RENAMES.get(t.__name__)
+        if legacy and legacy in names:
+            sql = f"ALTER TABLE {ftn} CHANGE COLUMN `{legacy}` {COLDEF}"
+            print(f"  RENAME  {t.__name__:30s} {legacy} -> insertion_time")
+            rename += 1
+        else:
+            sql = f"ALTER TABLE {ftn} ADD COLUMN {COLDEF}"
+            print(f"  ADD     {t.__name__:30s}")
+            add += 1
+        if args.apply:
+            conn.query(sql)
+
+    print(f"\n{add} ADD, {rename} RENAME, {skip} already done.")
+    print("APPLIED ✅" if args.apply else "DRY-RUN — pass --apply to execute.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_add_insertion_time.py
+++ b/scripts/migrate_add_insertion_time.py
@@ -4,11 +4,17 @@ Pairs with the `TimestampedSchema` change (pose_pipeline/dj_schema.py), which st
 tables automatically. This migration updates the *existing* database:
 
   - ADD    a `insertion_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP` column to every
-           Computed/Imported/Manual table that doesn't have one (Lookups/Parts skipped).
+           Computed/Imported/Manual table that doesn't have one (Lookups/Parts skipped), using
+           ALGORITHM=INSTANT (metadata-only, no table rebuild -- fast even on the largest tables).
            Existing rows get the migration time; new rows get their insert time.
-  - RENAME the 3 legacy timestamp fields to `insertion_time` (preserving the *real* historical
-           timestamps those tables already recorded): Video.import_time,
+  - RENAME the 3 legacy timestamp fields to `insertion_time` via RENAME COLUMN (a pure metadata
+           rename that preserves the *real* historical timestamps): Video.import_time,
            BottomUpPeople.timestamp, SkeletonAction.computed_timestamp.
+
+Locking: ALTERs run one table at a time (one brief metadata lock each), so this does not lock the
+whole DB. Each op is metadata-only/instant; the only stall risk is if a long-running transaction
+holds a lock on the specific table being altered -- prefer a quiet window. A per-table failure is
+reported and the run continues (idempotent: re-run to retry).
 
 Idempotent (safe to re-run). DRY-RUN by default; pass --apply to execute. Requires WRITE creds.
 
@@ -48,7 +54,7 @@ def main():
     ]
     print(f"schema: {db} | {len(tables)} Computed/Imported/Manual tables\n")
 
-    add = rename = skip = 0
+    add = rename = skip = fail = 0
     for t in sorted(tables, key=lambda c: c.__name__):
         names = t.heading.names
         ftn = t.full_table_name
@@ -58,18 +64,27 @@ def main():
             continue
         legacy = RENAMES.get(t.__name__)
         if legacy and legacy in names:
-            sql = f"ALTER TABLE {ftn} CHANGE COLUMN `{legacy}` {COLDEF}"
+            # pure metadata rename: preserves the column's type/default and its real historical values
+            sql = f"ALTER TABLE {ftn} RENAME COLUMN `{legacy}` TO `insertion_time`"
             print(f"  RENAME  {t.__name__:30s} {legacy} -> insertion_time")
             rename += 1
         else:
-            sql = f"ALTER TABLE {ftn} ADD COLUMN {COLDEF}"
+            # ALGORITHM=INSTANT: metadata-only add (no table rebuild); errors loudly if not possible
+            sql = f"ALTER TABLE {ftn} ADD COLUMN {COLDEF}, ALGORITHM=INSTANT"
             print(f"  ADD     {t.__name__:30s}")
             add += 1
         if args.apply:
-            conn.query(sql)
+            try:
+                conn.query(sql)
+            except Exception as e:  # keep going so one table can't halt the run; report at the end
+                print(f"          FAILED ({type(e).__name__}: {str(e)[:100]})")
+                fail += 1
 
-    print(f"\n{add} ADD, {rename} RENAME, {skip} already done.")
-    print("APPLIED ✅" if args.apply else "DRY-RUN — pass --apply to execute.")
+    print(f"\n{add} ADD, {rename} RENAME, {skip} already done" + (f", {fail} FAILED" if fail else "") + ".")
+    if args.apply:
+        print("APPLIED with FAILURES — re-run after investigating." if fail else "APPLIED ✅")
+    else:
+        print("DRY-RUN — pass --apply to execute.")
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_add_insertion_time.py
+++ b/scripts/migrate_add_insertion_time.py
@@ -1,20 +1,19 @@
-"""One-time migration to add `insertion_time` to existing pose_pipeline tables.
+"""One-time migration: give every pose_pipeline table a `<table>_inserted_at` timestamp column.
 
-Pairs with the `TimestampedSchema` change (pose_pipeline/dj_schema.py), which stamps *new*
-tables automatically. This migration updates the *existing* database:
+Pairs with the `TimestampedSchema` wrapper (pose_pipeline/dj_schema.py), which stamps *new* tables
+automatically; this brings the *existing* database in line. Per table (Lookups/Parts skipped), the
+target name is `inserted_at_attr(table)` (`<table>_inserted_at`), and:
 
-  - ADD    a `insertion_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP` column to every
-           Computed/Imported/Manual table that doesn't have one (Lookups/Parts skipped), using
-           ALGORITHM=INSTANT (metadata-only, no table rebuild -- fast even on the largest tables).
-           Existing rows get the migration time; new rows get their insert time.
-  - RENAME the 3 legacy timestamp fields to `insertion_time` via RENAME COLUMN (a pure metadata
-           rename that preserves the *real* historical timestamps): Video.import_time,
-           BottomUpPeople.timestamp, SkeletonAction.computed_timestamp.
+  - skip   if the table already has it;
+  - RENAME `insertion_time` -> target, if present (this repo's earlier rollout used the uniform
+           `insertion_time` name, which broke DataJoint joins -- two tables can't share a secondary
+           attribute; the per-table name fixes that). Pure metadata rename, keeps historical values;
+  - RENAME a legacy timestamp field -> target (see RENAMES), converting datetime->timestamp if needed;
+  - ADD    the column via ALGORITHM=INSTANT (metadata-only) otherwise. Existing rows get the
+           migration time; new rows get their insert time.
 
 Locking: ALTERs run one table at a time (one brief metadata lock each), so this does not lock the
-whole DB. Each op is metadata-only/instant; the only stall risk is if a long-running transaction
-holds a lock on the specific table being altered -- prefer a quiet window. A per-table failure is
-reported and the run continues (idempotent: re-run to retry).
+whole DB. A per-table failure is reported and the run continues.
 
 Idempotent (safe to re-run). DRY-RUN by default; pass --apply to execute. Requires WRITE creds.
 
@@ -22,16 +21,20 @@ Idempotent (safe to re-run). DRY-RUN by default; pass --apply to execute. Requir
     python scripts/migrate_add_insertion_time.py --apply    # execute
 """
 import argparse
+import importlib
 
 import datajoint as dj
 
-# tables whose existing timestamp field is RENAMED (keeps real historical values, not migration time)
-RENAMES = {
-    "Video": "import_time",
-    "BottomUpPeople": "timestamp",
-    "SkeletonAction": "computed_timestamp",
-}
-COLDEF = "`insertion_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+from pose_pipeline.dj_schema import inserted_at_attr
+
+# modules to import so their table classes are in scope
+MODULES = ["pose_pipeline.pipeline"]
+# only migrate tables that BELONG to these schemas (modules may import tables from other schemas)
+SCHEMAS = {"pose_pipeline"}
+# tables whose pre-existing (non-insertion_time) legacy timestamp field should be renamed instead of
+# adding a new column (ClassName -> legacy field). None here: this repo already ran the earlier
+# rollout, so its tables now carry `insertion_time`, which the RENAME-insertion_time branch handles.
+RENAMES = {}
 
 
 def main():
@@ -39,39 +42,48 @@ def main():
     ap.add_argument("--apply", action="store_true", help="execute the ALTERs (default: dry-run)")
     args = ap.parse_args()
 
-    import pose_pipeline.pipeline as P
-
     conn = dj.conn()
-    db = P.schema.database
-
-    tables = [
-        obj
-        for obj in vars(P).values()
-        if isinstance(obj, type)
-        and issubclass(obj, (dj.Computed, dj.Imported, dj.Manual))
-        and not issubclass(obj, dj.Part)
-        and getattr(obj, "database", None) == db
-    ]
-    print(f"schema: {db} | {len(tables)} Computed/Imported/Manual tables\n")
+    tables, seen = [], set()
+    for mn in MODULES:
+        mod = importlib.import_module(mn)
+        for obj in vars(mod).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, (dj.Computed, dj.Imported, dj.Manual))
+                and not issubclass(obj, dj.Part)
+                and getattr(obj, "database", None) in SCHEMAS  # skip tables imported from other schemas
+            ):
+                ftn = getattr(obj, "full_table_name", None)
+                if ftn and ftn not in seen:
+                    seen.add(ftn)
+                    tables.append(obj)
+    print(f"{len(tables)} Computed/Imported/Manual tables across {len(MODULES)} module(s)\n")
 
     add = rename = skip = fail = 0
     for t in sorted(tables, key=lambda c: c.__name__):
         names = t.heading.names
         ftn = t.full_table_name
-        if "insertion_time" in names:
-            print(f"  skip    {t.__name__:30s} (already has insertion_time)")
+        target = inserted_at_attr(t)
+        coldef = f"`{target}` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        if target in names:
+            print(f"  skip    {t.__name__:34s} (has {target})")
             skip += 1
             continue
-        legacy = RENAMES.get(t.__name__)
-        if legacy and legacy in names:
-            # pure metadata rename: preserves the column's type/default and its real historical values
-            sql = f"ALTER TABLE {ftn} RENAME COLUMN `{legacy}` TO `insertion_time`"
-            print(f"  RENAME  {t.__name__:30s} {legacy} -> insertion_time")
+        if "insertion_time" in names:  # correct the earlier uniform-name rollout
+            sql = f"ALTER TABLE {ftn} RENAME COLUMN `insertion_time` TO `{target}`"
+            print(f"  RENAME  {t.__name__:34s} insertion_time -> {target}")
+            rename += 1
+        elif (legacy := RENAMES.get(t.__name__)) and legacy in names:
+            typ = str(t.heading.attributes[legacy].type)
+            if typ.lower().startswith("timestamp"):
+                sql = f"ALTER TABLE {ftn} RENAME COLUMN `{legacy}` TO `{target}`"
+            else:  # legacy `datetime` field -> convert to timestamp while renaming
+                sql = f"ALTER TABLE {ftn} CHANGE COLUMN `{legacy}` {coldef}"
+            print(f"  RENAME  {t.__name__:34s} {legacy} ({typ}) -> {target}")
             rename += 1
         else:
-            # ALGORITHM=INSTANT: metadata-only add (no table rebuild); errors loudly if not possible
-            sql = f"ALTER TABLE {ftn} ADD COLUMN {COLDEF}, ALGORITHM=INSTANT"
-            print(f"  ADD     {t.__name__:30s}")
+            sql = f"ALTER TABLE {ftn} ADD COLUMN {coldef}, ALGORITHM=INSTANT"
+            print(f"  ADD     {t.__name__:34s} {target}")
             add += 1
         if args.apply:
             try:

--- a/tests/test_inserted_at.py
+++ b/tests/test_inserted_at.py
@@ -1,0 +1,99 @@
+"""Regression guard for the row-insertion-timestamp wrapper (``pose_pipeline/dj_schema.py``).
+
+Encodes the lesson from the insertion_time incident: a *uniform* secondary-attribute name on every
+table (``insertion_time``) breaks DataJoint natural joins, because DataJoint refuses to join two
+expressions that share a dependent (non-primary-key) attribute. The fix is a *distinct*
+``<table>_inserted_at`` per table. These tests fail if anyone regresses the naming back to a shared
+name, drops the 64-char safety, or loses idempotency -- and (with a DB) that stamped tables still join.
+"""
+import datajoint as dj
+import pytest
+
+from pose_pipeline.dj_schema import (
+    _MAX_ATTR_LEN,
+    TimestampedSchema,
+    add_inserted_at,
+    inserted_at_attr,
+)
+
+
+def _table(name, base=dj.Computed, definition="x : int"):
+    """Build a throwaway table class (not declared against any schema)."""
+    return type(name, (base,), {"definition": definition})
+
+
+# --- naming rule (no DB needed) ------------------------------------------------------------------
+
+def test_name_is_readable_per_table():
+    assert inserted_at_attr(_table("Video")) == "video_inserted_at"
+    assert inserted_at_attr(_table("KinematicReconstruction")) == "kinematic_reconstruction_inserted_at"
+
+
+def test_names_are_distinct_across_tables():
+    # THE core invariant: two different tables must never get the same stamped attribute name,
+    # otherwise `A * B` collides on a shared secondary attribute (the original breakage).
+    classes = ["Video", "VideoInfo", "TopDownPerson", "BottomUpPeople", "SMPLPerson", "PersonBbox"]
+    names = [inserted_at_attr(_table(c)) for c in classes]
+    assert len(names) == len(set(names)), f"stamped names collide: {names}"
+
+
+def test_every_name_ends_in_the_greppable_suffix():
+    for c in ["Video", "A" * 80]:
+        assert inserted_at_attr(_table(c)).endswith("_inserted_at")
+
+
+def test_add_is_idempotent():
+    cls = _table("Video")
+    add_inserted_at(cls)
+    once = cls.definition
+    add_inserted_at(cls)
+    assert cls.definition == once
+    assert cls.definition.count("video_inserted_at") == 1
+
+
+def test_long_name_falls_back_within_limit_and_stays_unique():
+    a, b = _table("A" * 80), _table("A" * 79)  # both would exceed 64 as <name>_inserted_at
+    for c in (a, b):
+        assert len(inserted_at_attr(c)) <= _MAX_ATTR_LEN
+    assert inserted_at_attr(a) != inserted_at_attr(b)  # hash disambiguates truncated names
+
+
+def test_lookup_and_part_are_not_stamped():
+    assert "inserted_at" not in add_inserted_at(_table("Cfg", dj.Lookup)).definition
+    assert "inserted_at" not in add_inserted_at(_table("Part", dj.Part)).definition
+
+
+# --- integration with the live schema (needs a DataJoint DB) -------------------------------------
+
+@pytest.fixture(scope="module")
+def _db():
+    try:
+        dj.conn()
+    except Exception as e:  # no DB configured (e.g. plain unit CI) -> skip the integration checks
+        pytest.skip(f"no DataJoint connection: {e}")
+
+
+def test_wrapper_is_used_and_no_uniform_name_remains(_db):
+    import pose_pipeline.pipeline as P
+
+    stamped = [
+        t
+        for t in vars(P).values()
+        if isinstance(t, type)
+        and issubclass(t, (dj.Computed, dj.Imported, dj.Manual))
+        and not issubclass(t, dj.Part)
+        and getattr(t, "database", None) == P.schema.database
+    ]
+    assert stamped, "expected pose_pipeline tables to introspect"
+    for t in stamped:
+        names = t.heading.names
+        assert "insertion_time" not in names, f"{t.__name__} still has the uniform insertion_time"
+        assert inserted_at_attr(t) in names, f"{t.__name__} missing {inserted_at_attr(t)}"
+
+
+def test_representative_join_builds(_db):
+    # the exact operation that failed under the uniform name must build without raising.
+    from pose_pipeline.pipeline import TopDownPerson, Video, VideoInfo
+
+    (Video * VideoInfo).heading  # noqa: B018  -- raised "Cannot join ... dependent attribute" before
+    (Video * TopDownPerson).heading  # noqa: B018


### PR DESCRIPTION
Summary

  This branch does two logically distinct things (kept together for deployment convenience; We did not want to add a new method for the pytorch version of bridging but adding the timestamps allows us to delineate TF/pytorch bridging):

  1. Ports the MeTRAbs "bridging" pose stage from TensorFlow to PyTorch and drops PosePipeline's TF dependencies. TensorFlow ships no Blackwell (sm_100/sm_120) kernels and builds against CUDA ≤12.3, so its GPU path is dead on the lab's new Blackwell server (needs CUDA 12.8+). PyTorch has cu128 wheels. Bridging feeds the entire reconstruction pipeline, so the port was validated numerically equivalent to the TF model before switching.
  2. Adds an automatic row-insertion timestamp to every table (<table>_inserted_at), for provenance and inter-stage timing. (Companion migrations live in the MultiCameraTracking / GaitAnalytics / BodyModels PRs.)

  1 — TF → PyTorch bridging

  - wrappers/bridging.py: loads the PyTorch MeTRAbs (our fork, weights auto-download on first use) in place of hub.load(...); ported the augmentation-noise math; stored output formats unchanged (keypoints3d, keypoints2d, confidence, boxes) so downstream tables are untouched. torch is imported lazily inside the three functions that need it.
  - pyproject.toml: removed tensorflow[and-cuda] / tensorflow-hub / tf-keras; added metrabs-pytorch @  …/metrabs@v0.1-pytorch-inference (our fork), posepile, simplepyutils, cameralib, ultralytics, hydra-core; torch index bumped cu124 → cu128.
  - Single method identity. Rather than register new _pt method ids (which would make the orchestrator treat every historical session as unprocessed and mass-reprocess under an unfiltered scope), PyTorch computes under the existing Bridging_bml_movi_87. The earlier _pt cascade was reverted, so the net pose-model diff here is just bridging.py + pyproject.toml.

  Equivalence validation (go/no-go gate)

  Validated PyTorch ≈ TF end-to-end on real data, up to the point bridging feeds reconstruction:
  - Keypoints: median ~1.4 px (with TF-confidence gating — PyTorch actually succeeds on ~5% of frames where TF returns a degenerate/failed pose).
  - Multi-cam downstream: ΔR ≈ 0.17 px reprojection (< ~1° joint angle).
  - Monocular: shape error ~9.2 mm, within the ~14 mm fit residual (mean-centered, shape-only).
  - Model metadata: 24/24 skeletons byte-identical; coco_25 identical; accessors return human joint names. Timing not worse than TF at production params (num_aug=10).

  2 — Per-table insertion timestamps

  - dj_schema.py: TimestampedSchema (drop-in for dj.schema) auto-appends <table>_inserted_at to every Computed/Imported/Manual table at declare time (Lookups/Parts skipped), with a hash-abbrev fallback for names > 64 chars.
  - Per-table name, not a uniform one. A first attempt used a single insertion_time on every table; DataJoint refuses to natural-join two expressions that share a secondary attribute, so that broke A * B joins across any two stamped tables (even Video * VideoInfo). The <table>_inserted_at name keeps joins working.
  - scripts/migrate_add_insertion_time.py: brings the existing DB in line (RENAME the prior insertion_time / legacy timestamp fields, else ADD via ALGORITHM=INSTANT). Already applied to the live DB.
  - tests/test_inserted_at.py: regression guard — distinct per-table names, 64-char fallback, idempotency, and that stamped tables still join.